### PR TITLE
remove js dom

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -50,7 +50,6 @@ object flicflac extends AppScalaModule {
   object shared extends Module {
     trait SharedModule extends AppScalaModule with PlatformScalaModule {
       def ivyDeps = super.ivyDeps() ++ Agg(
-        ivy"org.scala-js::scalajs-dom::2.8.0",
         ivy"org.http4s::http4s-circe:${http4sVersion}",
         ivy"com.outr::scribe::3.16.0",
         ivy"io.circe::circe-core::$circeV",


### PR DESCRIPTION
JS dom shouldn't have been a dependancy here. 

This is a shared dependancy, so it it won't compile on the JVM. 

The JS Dom dependance for the frontend, is already in the client module here;
https://github.com/Quafadas/FlicFlac/blob/841e0ac089ea94481ac770e05c8ea88f2f8bcd73/build.mill#L73


Hopefully, this will fix your build problem. 
