### PR TITLE
Fix timezones

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,6 +71,7 @@ object flicflac extends AppScalaModule {
     def moduleDeps = Seq(shared.js)
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"io.github.cquiroz::scala-java-time::2.5.0",
+      ivy"io.github.cquiroz::scala-java-time-tzdb::2.6.0",
       ivy"org.scala-js::scalajs-dom::2.8.0",
       ivy"io.indigoengine::indigo::0.17.0",
       ivy"io.indigoengine::indigo-extras::0.17.0",

--- a/flicflac/client/src/GameStorage.scala
+++ b/flicflac/client/src/GameStorage.scala
@@ -141,7 +141,7 @@ final case class GameStorage(
   end readGameStorage
 
   def dateForGameStorage(): String =
-    val current = java.time.LocalDateTime.now()
+    val current = java.time.LocalDateTime.now(java.time.Clock.systemUTC())
     val fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd")
     val dString = current.format(fmt)
     dString

--- a/flicflac/client/src/GameStorage.scala
+++ b/flicflac/client/src/GameStorage.scala
@@ -12,7 +12,6 @@ import game.hexBoard4
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-
 val GAME_INDEX_FILE = "FlicFlac-Index"
 val GAME_PREFIX = "###-"
 
@@ -131,9 +130,9 @@ final case class GameStorage(
         scribe.debug("@@@ readGameStorage:" + storageName + " has " + gs.turns.length + " turns")
 
         // FIXME
-        //val testString = dateForGameStorage()
-        //scribe.debug("@@@ testString:" + testString)
-        
+        val testString = dateForGameStorage()
+        scribe.debug("@@@ testString:" + testString)
+
         Some(gs)
       case Left(_) =>
         scribe.debug("@@@ readGameStorage:" + storageName + " not found")
@@ -141,7 +140,7 @@ final case class GameStorage(
     possibleGameStorage
   end readGameStorage
 
-  def dateForGameStorage() : String =
+  def dateForGameStorage(): String =
     val current = java.time.LocalDateTime.now()
     val fmt = DateTimeFormatter.ofPattern("yyyy-MM-dd")
     val dString = current.format(fmt)


### PR DESCRIPTION
There are two options; I've tried to included both in this PR. 

`val current = java.time.LocalDateTime.now(java.time.Clock.systemUTC())` forces the date to always be UTC - means there are no timezone concerns. 

If you want timezone localisation, then you'd need the tzDB dependancy 

https://cquiroz.github.io/scala-java-time/

according to the docs. I think it is quite heavy and could slow load times, particularly on a mobile connection. I've _also_ added that to build.mill.

I believe it would not be necessary to include, if you were to always constrain times to be UTC... depends how much you care about localisation I guess :-). 